### PR TITLE
Implement automatic ISO date to YYYYMMDD conversion for date parameters

### DIFF
--- a/configs/microsoft365.json
+++ b/configs/microsoft365.json
@@ -41,7 +41,7 @@
           "parameters": [
             {
               "name": "startDate",
-              "description": "Start date in YYYYMMDD format",
+              "description": "Start date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS-7 for last week, #DAYS+0 for today)",
               "type": "string",
               "required": true,
               "location": "query",
@@ -55,7 +55,7 @@
             },
             {
               "name": "endDate",
-              "description": "End date in YYYYMMDD format",
+              "description": "End date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS+7 for next week, #DAYS+0 for today)",
               "type": "string",
               "required": true,
               "location": "query",
@@ -112,7 +112,7 @@
           "parameters": [
             {
               "name": "startDate",
-              "description": "Start date in YYYYMMDD format",
+              "description": "Start date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS-7 for last week, #DAYS+0 for today)",
               "type": "string",
               "required": true,
               "location": "query",
@@ -126,7 +126,7 @@
             },
             {
               "name": "endDate",
-              "description": "End date in YYYYMMDD format",
+              "description": "End date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS+7 for next week, #DAYS+0 for today)",
               "type": "string",
               "required": true,
               "location": "query",
@@ -262,7 +262,7 @@
             },
             {
               "name": "startDate",
-              "description": "Start date in YYYYMMDD format",
+              "description": "Start date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS-7 for last week, #DAYS+0 for today)",
               "type": "string",
               "required": false,
               "location": "query",
@@ -276,7 +276,7 @@
             },
             {
               "name": "endDate",
-              "description": "End date in YYYYMMDD format",
+              "description": "End date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS+7 for next week, #DAYS+0 for today)",
               "type": "string",
               "required": false,
               "location": "query",
@@ -341,7 +341,7 @@
             },
             {
               "name": "startDate",
-              "description": "Start date in YYYYMMDD format",
+              "description": "Start date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS-7 for last week, #DAYS+0 for today)",
               "type": "string",
               "required": false,
               "location": "query",
@@ -355,7 +355,7 @@
             },
             {
               "name": "endDate",
-              "description": "End date in YYYYMMDD format",
+              "description": "End date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS+7 for next week, #DAYS+0 for today)",
               "type": "string",
               "required": false,
               "location": "query",
@@ -549,7 +549,7 @@
             {
               "name": "$filter",
               "alias": "filter",
-              "description": "Filter expression (e.g., 'isRead eq false')",
+              "description": "OData filter expression. Use time tokens: #DAYS-N (N days ago), #DAYS+N (N days in future), #HOURS-N (N hours ago), #HOURS+N (N hours in future). Examples: 'isRead eq false', 'receivedDateTime ge #DAYS-1', 'receivedDateTime le #DAYS+7'",
               "type": "string",
               "required": false,
               "location": "query"
@@ -649,7 +649,7 @@
             {
               "name": "$filter",
               "alias": "filter",
-              "description": "Filter expression",
+              "description": "OData filter expression. Use time tokens: #DAYS-N (N days ago), #DAYS+N (N days in future), #HOURS-N (N hours ago), #HOURS+N (N hours in future). Examples: 'isRead eq false', 'receivedDateTime ge #DAYS-1', 'createdDateTime le #DAYS+30'",
               "type": "string",
               "required": false,
               "location": "query"
@@ -705,7 +705,7 @@
           "parameters": [
             {
               "name": "startDate",
-              "description": "Start date in YYYYMMDD format",
+              "description": "Start date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS-7 for last week, #DAYS+0 for today)",
               "type": "string",
               "required": true,
               "location": "query",
@@ -719,7 +719,7 @@
             },
             {
               "name": "endDate",
-              "description": "End date in YYYYMMDD format",
+              "description": "End date in YYYYMMDD format. Use #DAYS-N for N days ago or #DAYS+N for N days in future (e.g., #DAYS+7 for next week, #DAYS+0 for today)",
               "type": "string",
               "required": true,
               "location": "query",
@@ -907,7 +907,7 @@
             {
               "name": "$filter",
               "alias": "filter",
-              "description": "OData filter expression. Examples: file/mimeType eq 'application/pdf', lastModifiedDateTime ge 2025-01-01T00:00:00Z, size gt 1048576",
+              "description": "OData filter expression. Use time tokens: #DAYS-N (N days ago), #DAYS+N (N days in future), #HOURS-N (N hours ago), #HOURS+N (N hours in future). Examples: file/mimeType eq 'application/pdf', lastModifiedDateTime ge #DAYS-7, size gt 1048576, createdDateTime le #DAYS+30",
               "type": "string",
               "required": false,
               "location": "query",
@@ -974,7 +974,7 @@
             {
               "name": "$filter",
               "alias": "filter",
-              "description": "OData filter expression. Examples: file/mimeType eq 'application/pdf', folder ne null, file ne null",
+              "description": "OData filter expression. Use time tokens: #DAYS-N (N days ago), #DAYS+N (N days in future), #HOURS-N (N hours ago), #HOURS+N (N hours in future). Examples: file/mimeType eq 'application/pdf', folder ne null, file ne null, lastModifiedDateTime ge #DAYS-30",
               "type": "string",
               "required": false,
               "location": "query",
@@ -1163,7 +1163,7 @@
             {
               "name": "$filter",
               "alias": "filter",
-              "description": "Filter results by type or properties",
+              "description": "OData filter expression. Use time tokens: #DAYS-N (N days ago), #DAYS+N (N days in future), #HOURS-N (N hours ago), #HOURS+N (N hours in future) for date filtering. Examples: givenName eq 'John', department eq 'Engineering', createdDateTime ge #DAYS-30",
               "type": "string",
               "required": false,
               "location": "query",
@@ -1355,7 +1355,7 @@
             {
               "name": "$filter",
               "alias": "filter",
-              "description": "Filter results by type or properties",
+              "description": "OData filter expression. Use time tokens: #DAYS-N (N days ago), #DAYS+N (N days in future), #HOURS-N (N hours ago), #HOURS+N (N hours in future) for date filtering. Examples: givenName eq 'John', department eq 'Engineering', createdDateTime ge #DAYS-30",
               "type": "string",
               "required": false,
               "location": "query",

--- a/fusion/validator_date_test.go
+++ b/fusion/validator_date_test.go
@@ -1,0 +1,189 @@
+/******************************************************************************
+ * Copyright (c) 2025 Tenebris Technologies Inc.                              *
+ * All rights reserved.                                                       *
+ ******************************************************************************/
+
+package fusion
+
+import (
+	"testing"
+
+	"github.com/PivotLLM/MCPFusion/mlogger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidator_AutoConvertISOToYYYYMMDD(t *testing.T) {
+	logger, err := mlogger.New(mlogger.WithDebug(true))
+	require.NoError(t, err)
+	
+	validator := NewValidator(logger)
+
+	// Test parameter configuration for YYYYMMDD format
+	params := []ParameterConfig{
+		{
+			Name:        "startDate",
+			Description: "Start date in YYYYMMDD format",
+			Type:        "string",
+			Required:    true,
+			Location:    "query",
+			Validation: &ValidationConfig{
+				Pattern: "^\\d{8}$", // YYYYMMDD pattern
+			},
+		},
+	}
+
+	tests := []struct {
+		name          string
+		inputValue    string
+		expectedValue string
+		shouldPass    bool
+	}{
+		{
+			name:          "Convert ISO with timezone",
+			inputValue:    "2025-08-19T00:00:00Z",
+			expectedValue: "20250819",
+			shouldPass:    true,
+		},
+		{
+			name:          "Convert ISO with milliseconds",
+			inputValue:    "2025-12-25T00:00:00.000Z",
+			expectedValue: "20251225",
+			shouldPass:    true,
+		},
+		{
+			name:          "Convert date only format",
+			inputValue:    "2025-01-15",
+			expectedValue: "20250115",
+			shouldPass:    true,
+		},
+		{
+			name:          "Pass through valid YYYYMMDD",
+			inputValue:    "20250819",
+			expectedValue: "20250819",
+			shouldPass:    true,
+		},
+		{
+			name:          "Reject invalid format",
+			inputValue:    "invalid-date",
+			expectedValue: "",
+			shouldPass:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create args map with test value
+			args := map[string]interface{}{
+				"startDate": tt.inputValue,
+			}
+
+			// Validate parameters
+			err := validator.ValidateParameters(params, args)
+
+			if tt.shouldPass {
+				assert.NoError(t, err, "Validation should pass for %s", tt.name)
+				
+				// Check that the value was converted correctly
+				actualValue, exists := args["startDate"]
+				assert.True(t, exists, "Parameter should exist after validation")
+				assert.Equal(t, tt.expectedValue, actualValue, "Value should be converted to YYYYMMDD format")
+			} else {
+				assert.Error(t, err, "Validation should fail for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidator_tryConvertISOToYYYYMMDD(t *testing.T) {
+	logger, err := mlogger.New(mlogger.WithDebug(false))
+	require.NoError(t, err)
+	
+	validator := NewValidator(logger)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		description string
+	}{
+		{
+			name:        "RFC3339 with Z",
+			input:       "2025-08-19T00:00:00Z",
+			expected:    "20250819",
+			description: "Standard ISO format with Z timezone",
+		},
+		{
+			name:        "RFC3339 with milliseconds",
+			input:       "2025-12-25T15:30:45.123Z",
+			expected:    "20251225",
+			description: "ISO format with milliseconds and Z timezone",
+		},
+		{
+			name:        "RFC3339 with timezone offset",
+			input:       "2025-01-01T12:00:00-08:00",
+			expected:    "20250101",
+			description: "ISO format with timezone offset",
+		},
+		{
+			name:        "Date only format",
+			input:       "2025-06-15",
+			expected:    "20250615",
+			description: "Simple YYYY-MM-DD format",
+		},
+		{
+			name:        "Invalid format",
+			input:       "not-a-date",
+			expected:    "",
+			description: "Should return empty string for invalid format",
+		},
+		{
+			name:        "Already YYYYMMDD",
+			input:       "20250819",
+			expected:    "",
+			description: "Should return empty string as it's not an ISO format to convert",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validator.tryConvertISOToYYYYMMDD(tt.input)
+			assert.Equal(t, tt.expected, result, tt.description)
+		})
+	}
+}
+
+func TestValidator_NoConversionForNonDatePatterns(t *testing.T) {
+	logger, err := mlogger.New(mlogger.WithDebug(false))
+	require.NoError(t, err)
+	
+	validator := NewValidator(logger)
+
+	// Test parameter configuration for non-YYYYMMDD pattern
+	params := []ParameterConfig{
+		{
+			Name:        "emailField",
+			Description: "Email address",
+			Type:        "string",
+			Required:    true,
+			Location:    "query",
+			Validation: &ValidationConfig{
+				Pattern: "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", // Email pattern
+			},
+		},
+	}
+
+	// Create args map with ISO date (should not be converted for non-date fields)
+	args := map[string]interface{}{
+		"emailField": "2025-08-19T00:00:00Z",
+	}
+
+	// Validate parameters - should fail because ISO date doesn't match email pattern
+	err = validator.ValidateParameters(params, args)
+	assert.Error(t, err, "Validation should fail as ISO date doesn't match email pattern")
+	
+	// Verify the value was not modified
+	actualValue, exists := args["emailField"]
+	assert.True(t, exists, "Parameter should still exist")
+	assert.Equal(t, "2025-08-19T00:00:00Z", actualValue, "Value should not be modified for non-date patterns")
+}

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func main() {
 	}
 
 	// My default log in the current directory
-	logfile := "mcp.log"
+	logfile := "mcpfusion.log"
 
 	// If MCP_FUSION_LOGFILE is set, use it instead
 	value, exists := os.LookupEnv("MCP_FUSION_LOGFILE")


### PR DESCRIPTION
- Add smart date format conversion in validator for YYYYMMDD patterns
- Auto-convert ISO dates (2025-08-19T00:00:00Z) to YYYYMMDD format (20250819)
- Support multiple ISO formats: RFC3339, RFC3339 with milliseconds, date-only
- Only activate conversion for parameters with '^\\d{8}$' validation pattern
- Update microsoft365.json with comprehensive #DAYS macro documentation
- Add comprehensive test coverage for date conversion functionality

This enables seamless use of #DAYS-N and #DAYS+N macros in calendar date parameters while maintaining strict validation. LLMs can now use consistent macro syntax (#DAYS-7) for both filter parameters and date fields.

Examples:
- microsoft365_calendar_read_summary startDate="#DAYS-7" → startDate="20250813"
- microsoft365_mail_read_inbox filter="receivedDateTime ge #DAYS-1" → unchanged
