### PR TITLE
fix: strip finding details from pwndoc_get_audit to prevent size limit errors

### DIFF
--- a/configs/pwndoc.json
+++ b/configs/pwndoc.json
@@ -42,7 +42,7 @@
         {
           "id": "get_audit",
           "name": "Get Audit",
-          "description": "Get detailed information about a specific audit including all findings, scope, sections, and metadata",
+          "description": "Get audit metadata and a summary of findings (ID, identifier, title, priority, status, CVSS, category). Full finding details are intentionally excluded — use pwndoc_get_finding with the returned _id to retrieve the complete details of any specific finding. Section content is also excluded — use pwndoc_get_audit_sections for section text.",
           "method": "GET",
           "path": "/api/audits/{audit_id}",
           "parameters": [
@@ -54,7 +54,10 @@
               "location": "path"
             }
           ],
-          "response": { "type": "json" }
+          "response": {
+            "type": "json",
+            "transform": ".datas | {_id, name, auditType, language, state, createdAt, creator, collaborators, reviewers, company, client, findings: [.findings[] | {_id, identifier, title, priority, status, cvssv3, category}]}"
+          }
         },
         {
           "id": "create_audit",

--- a/global/version.go
+++ b/global/version.go
@@ -8,5 +8,5 @@ package global
 // Version information
 const (
 	AppName    = "MCPFusion"
-	AppVersion = "0.3.3"
+	AppVersion = "0.3.4"
 )


### PR DESCRIPTION
## Summary
- Applied a JQ transform to `pwndoc_get_audit` so it always returns finding summaries only (`_id`, `identifier`, `title`, `priority`, `status`, `cvssv3`, `category`) instead of full finding content
- Eliminates the inconsistent "Response too large" error on audits with many detailed findings
- Updated tool description to direct users to `pwndoc_get_finding` for full details
- Bumped version to v0.3.4

## Test plan
- [x] Tested `pwndoc_get_audit` on audit `69a393eca58aa60722b924ad` (previously 84,650 bytes / failed) — now returns cleanly
- [x] Build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)