### PR TITLE
feat: save binary responses to MCP_FUSION_DL_DIR

### DIFF
--- a/fusion/fusion.go
+++ b/fusion/fusion.go
@@ -111,6 +111,10 @@ type Fusion struct {
 	// Responses exceeding this limit are replaced with an informational message.
 	// A value of 0 disables the limit.
 	maxResponseBytes int
+
+	// downloadDir is the directory where binary responses are saved.
+	// If empty, binary responses return an informational message only.
+	downloadDir string
 }
 
 // NativeToolPrefixRegistrar allows registering prefixes for native (non-config-driven)
@@ -288,6 +292,14 @@ func WithMultiTenantAuth(multiTenantAuth *MultiTenantAuthManager) Option {
 func WithExternalURL(url string) Option {
 	return func(f *Fusion) {
 		f.externalURL = url
+	}
+}
+
+// WithDownloadDir sets the directory where binary responses (e.g. DOCX files) are saved.
+// If the directory does not exist, Fusion will attempt to create it.
+func WithDownloadDir(dir string) Option {
+	return func(f *Fusion) {
+		f.downloadDir = dir
 	}
 }
 
@@ -505,6 +517,11 @@ func (f *Fusion) GetLogger() global.Logger {
 // A value of 0 means no limit is enforced.
 func (f *Fusion) MaxResponseBytes() int {
 	return f.maxResponseBytes
+}
+
+// DownloadDir returns the configured download directory for binary responses.
+func (f *Fusion) DownloadDir() string {
+	return f.downloadDir
 }
 
 // RegisterTools implements the global.ToolProvider interface and dynamically generates

--- a/fusion/handler.go
+++ b/fusion/handler.go
@@ -15,6 +15,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -671,14 +673,82 @@ func (h *HTTPHandler) handleResponse(resp *http.Response, correlationID string, 
 		return string(body), nil
 
 	case "binary":
-		// For binary responses, return base64 encoded string
-		// This is a simplified implementation
-		return fmt.Sprintf("Binary data (%d bytes)", len(body)), nil
+		dlDir := h.fusion.DownloadDir()
+		if dlDir == "" {
+			return fmt.Sprintf("Binary data (%d bytes). Set MCP_FUSION_DL_DIR to save downloads to disk.", len(body)), nil
+		}
+
+		// Ensure download directory exists
+		if err := os.MkdirAll(dlDir, 0750); err != nil {
+			return "", fmt.Errorf("failed to create download directory %s: %w", dlDir, err)
+		}
+
+		// Determine file extension from Content-Type
+		ext := extensionFromContentType(resp.Header.Get("Content-Type"))
+
+		// Build filename: <service>_<endpoint>_<timestamp><ext>
+		filename := fmt.Sprintf("%s_%s_%s%s",
+			sanitizeFilename(h.service.Name),
+			sanitizeFilename(h.endpoint.ID),
+			time.Now().Format("20060102_150405"),
+			ext,
+		)
+		filePath := filepath.Join(dlDir, filename)
+
+		if err := os.WriteFile(filePath, body, 0640); err != nil {
+			return "", fmt.Errorf("failed to write download to %s: %w", filePath, err)
+		}
+
+		if h.fusion.logger != nil {
+			h.fusion.logger.Infof("Binary response saved: %s (%d bytes)", filePath, len(body))
+		}
+
+		return fmt.Sprintf("File saved to %s (%d bytes)", filePath, len(body)), nil
 
 	default:
 		// Default to JSON
 		return string(body), nil
 	}
+}
+
+// extensionFromContentType returns a file extension for common MIME types.
+func extensionFromContentType(contentType string) string {
+	// Strip parameters (e.g. "; charset=utf-8")
+	if i := strings.Index(contentType, ";"); i >= 0 {
+		contentType = strings.TrimSpace(contentType[:i])
+	}
+	switch contentType {
+	case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+		return ".docx"
+	case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+		return ".xlsx"
+	case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+		return ".pptx"
+	case "application/pdf":
+		return ".pdf"
+	case "application/zip":
+		return ".zip"
+	case "text/plain":
+		return ".txt"
+	case "text/csv":
+		return ".csv"
+	default:
+		return ".bin"
+	}
+}
+
+// sanitizeFilename replaces characters that are unsafe in filenames with underscores.
+func sanitizeFilename(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r == '/' || r == '\\' || r == ':' || r == '*' || r == '?' ||
+			r == '"' || r == '<' || r == '>' || r == '|' || r == ' ' {
+			b.WriteRune('_')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // wrapNetworkError wraps network errors in NetworkError type

--- a/global/version.go
+++ b/global/version.go
@@ -8,5 +8,5 @@ package global
 // Version information
 const (
 	AppName    = "MCPFusion"
-	AppVersion = "0.3.4"
+	AppVersion = "0.3.5"
 )

--- a/main.go
+++ b/main.go
@@ -110,7 +110,8 @@ func main() {
 		fmt.Printf("  -auth-token string\n")
 		fmt.Printf("        API token prefix/hash to identify tenant (for multi-token setups)\n\n")
 		fmt.Printf("Environment Variables:\n")
-		fmt.Printf("  MCP_FUSION_DB_DIR   Custom database directory (default: /opt/mcpfusion or ~/.mcpfusion)\n\n")
+		fmt.Printf("  MCP_FUSION_DB_DIR   Custom database directory (default: /opt/mcpfusion or ~/.mcpfusion)\n")
+		fmt.Printf("  MCP_FUSION_DL_DIR   Directory for saving binary downloads (e.g. generated reports)\n\n")
 		fmt.Printf("Examples:\n")
 		fmt.Printf("  # Start server with configuration\n")
 		fmt.Printf("  %s -config configs/microsoft365.json -port 8888\n\n", os.Args[0])
@@ -365,6 +366,12 @@ func main() {
 		} else {
 			fusionOpts = append(fusionOpts, fusion.WithExternalURL("http://"+listen))
 			logger.Warningf("MCP_FUSION_EXTERNAL_URL not set, using http://%s (may not be reachable externally)", listen)
+		}
+
+		// Set download directory for binary responses
+		if dlDir := os.Getenv("MCP_FUSION_DL_DIR"); dlDir != "" {
+			fusionOpts = append(fusionOpts, fusion.WithDownloadDir(dlDir))
+			logger.Infof("Download directory: %s", dlDir)
 		}
 
 		// Add multi-tenant support if available


### PR DESCRIPTION
## Summary
- Adds `MCP_FUSION_DL_DIR` environment variable; when set, binary responses (e.g. generated DOCX reports) are written to disk instead of discarded
- Directory is created automatically if it does not exist
- Filenames are derived from service name, endpoint ID, and timestamp with extension inferred from `Content-Type` (`.docx`, `.pdf`, `.xlsx`, `.zip`, `.txt`, `.csv`, `.bin`)
- Returns the saved file path to the caller
- Bumped version to v0.3.5

## Test plan
- [x] `pwndoc_generate_audit_report` tested against ELB Asset Library audit — 596KB DOCX downloaded successfully
- [x] Build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)